### PR TITLE
Fix demo code of polling sockets in assignment7.html

### DIFF
--- a/assignment7.html
+++ b/assignment7.html
@@ -312,7 +312,7 @@ if(ret &lt; 0)
 // ... connect socket ...
 
 std::vector&lt;CS2Net::PollFD&gt; poll_vec(1);
-poll_vec[0].sock = sock;
+poll_vec[0].sock = &sock;
 poll_vec[0].SetRead(true);
 // now do the poll (10 ms timeout)
 int poll_err = CS2Net::Poll(&amp;poll_vec, 10);


### PR DESCRIPTION
In NetworkWrapper.hpp, the struct PollFD has a member socket which is a pointer to a Socket object:

struct PollFD
{
    Socket \* sock;  
    ...
}

NetworkWrapper.cpp confirmed that 'sock' is a pointer:

fds[i].fd       = (*to_poll)[i].sock->GetSocketFileDescriptor();

In assignment7.html, it used the member as a Socket object:

poll_vec[0].sock = sock;

So I changed this line in assignment7.html to be:

poll_vec[0].sock = &sock;
