### PR TITLE
Change default port number

### DIFF
--- a/client2.glade
+++ b/client2.glade
@@ -370,7 +370,7 @@
   </object>
   <object class="GtkAdjustment" id="port_number">
     <property name="upper">65535</property>
-    <property name="value">42002</property>
+    <property name="value">47002</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>


### PR DESCRIPTION
Default port number is 42002 (an old port) while we are using 47002 this year.
